### PR TITLE
Add SolveLogs to Visualizations

### DIFF
--- a/readme-en.md
+++ b/readme-en.md
@@ -95,6 +95,7 @@ Language: **[😎 English](readme-en.md)** • [한국어 (Korean)](readme-ko.md
 - [Vamonos](http://rosulek.github.io/vamonos) - JavaScript Programming Language.
 - [The Sound of Sorting](http://panthema.net/2013/sound-of-sorting) - C ++ Programming Language.
 - [GeneaQuilts](http://www.aviz.fr/geneaquilts) - Java Programming Language.
+- [SolveLogs](https://solvelogs.com) - Python, C++, Java Programming Languages.
 
 ## Interviews
 - [Interview Cake](https://www.interviewcake.com)

--- a/readme-ko.md
+++ b/readme-ko.md
@@ -108,6 +108,7 @@
 - [Vamonos](http://rosulek.github.io/vamonos) - JavaScript 프로그래밍 언어.
 - [The Sound of Sorting](http://panthema.net/2013/sound-of-sorting) - C ++ 프로그래밍 언어.
 - [GeneaQuilts](http://www.aviz.fr/geneaquilts) - Java 프로그래밍 언어.
+- [SolveLogs](https://solvelogs.com) - Python, C++, Java 프로그래밍 언어.
 
 ## Interviews
 > 인터뷰


### PR DESCRIPTION
Hello, and thank you for maintaining this list — the Visualizations section is a lovely collection, and it's clearly had a lot of care put into it over the years.

I'd like to suggest SolveLogs (https://solvelogs.com) for that section. It's a free site with interactive step-by-step tracers that show an algorithm's state changing one step at a time, with Python, C++ and Java implementations for each topic.

I've followed the existing convention of noting the programming languages after the description, and updated both readme-en.md and readme-ko.md so the two stay in sync. Please do correct my Korean phrasing if it reads awkwardly — I matched the pattern of the surrounding entries but I'm not a native speaker.

Entirely understand if this isn't a fit or if the list isn't taking additions at the moment. Happy to close it myself, and thank you regardless for the time.